### PR TITLE
S-01014 ＹＥＳ本社が、引き当てたエンジンの引当を取り消す（流通ステータスの） ※ただし、完了していない時だけ

### DIFF
--- a/app/controllers/engineorders_controller.rb
+++ b/app/controllers/engineorders_controller.rb
@@ -81,6 +81,14 @@ class EngineordersController < ApplicationController
   # PATCH/PUT /engineorders/1
   # PATCH/PUT /engineorders/1.json
   def update
+    # すでに新エンジンが登録されていて、入力された新エンジンが現在の新エンジン
+    # と異なる場合、一旦引当の取消が必要と判断する
+    if new_engine = @engineorder.new_engine
+      unless new_engine.id == engineorder_params[:new_engine_id]
+        @engineorder.undo_allocation
+      end
+    end
+
     # 流通ステータスをセットする。(privateメソッド)
     setBusinessstatus
 


### PR DESCRIPTION
- 引当を取り消して、別の新エンジンを引当るための変更です
- 受注→引当（新エンジン＝エンジン１）→引当取り消し→引当（新エンジン＝エンジン２） の操作を、一括実行できるようになります
- 「引当」状態の流通情報の「引当」リンク、または、「修正」リンクから表示する引当登録画面で新エンジンを切り替えることで実行できます
- 切り替え前の新エンジンは、切り替え後に「完成品」状態に戻り、サスペンドされなくなります
