### PR TITLE
IE8 でのエンジン一覧画面のレイアウト乱れを修正

### DIFF
--- a/app/views/engines/index.html.erb
+++ b/app/views/engines/index.html.erb
@@ -1,8 +1,9 @@
 <h1 class="title">エンジン一覧</h1>
 
 <h3>検索条件</h3>
-<%= form_tag engines_index_path, :method => :get do %>
+
 <div class="well">
+  <%= form_tag engines_index_path, :method => :get do %>
   <table>
     <% if current_user.yesOffice? %>
       <tr>
@@ -33,7 +34,7 @@
 <table class="table table-striped table-bordered table-condensed">
   <thead>
     <tr>
-      <th>ステータス</th>      
+      <th>ステータス</th>
       <th>エンジン型式</th>
       <th>エンジンNo.</th>
       <% if current_user.yesOffice? %>
@@ -64,7 +65,9 @@
         <td><%= display_suspended_or_not(engine) %></td>
 
 
-        <% unless current_user.tender? %>
+        <% if current_user.tender? %>
+          <td></td>
+        <% else %>
           <td class="workregist"><%= link_to '引合', new_inquiry_path(engine), class: "workregist_work" %> </td>
         <% end %>
 
@@ -80,8 +83,12 @@
           <td class="workregist"><%= link_to '修正', edit_engine_path(engine) , class: "workregist_edit" %></td>
           <td class="workregist"><%= link_to '削除', engine, method: :delete, data: { confirm: '本当に削除してもよろしいですか？' } , class: "workregist_del" %>
           </td>
-     　　 <% end %>  
-      　　</tr>
+        <% else %>
+          <td></td>
+          <td></td>
+          <td></td>
+        <% end %>
+      </tr>
     <% end %>
   </tbody>
 </table>


### PR DESCRIPTION
`<tbody>` 内の `<td>` 要素数が、ログインユーザによってまちまちになってしまうのが原因でした
