### PR TITLE
Sprint7

### DIFF
--- a/app/views/engineorders/inquiry.html.erb
+++ b/app/views/engineorders/inquiry.html.erb
@@ -39,7 +39,11 @@
 
   <div class="field">
     <%= f.label :salesman_id %><br>
-   <%= f.collection_select( :salesman_id, User.all, :id, :name, :include_blank => false ) %>
+    <% if current_user.yesOffice? %>
+      <%= f.collection_select( :salesman_id, User.all, :id, :name, :include_blank => false, :selected => current_user.id ) %>
+    <% else %>
+      <%= f.collection_select( :salesman_id, User.all, :id, :name, options = {:include_blank => true, :selected => current_user.id}, html_options = {:disabled => :disabled} ) %>
+    <% end %>
   </div>
 
   <%= render "location", {f: f, attr_name: "install_place", location: @engineorder.install_place,disabled_info: false } %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -125,9 +125,9 @@ ActiveRecord::Schema.define(version: 20140131999999) do
     t.string   "userid"
     t.string   "name"
     t.string   "category"
-    t.integer  "company_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "company_id"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true


### PR DESCRIPTION
Story S-01062　流通情報登録の担当者情報を、ログインしてるユーザーの情報とする
　・ログインユーザの所属する法人の分類が、「ＹＥＳ本社」の場合
　　→ 担当者のデフォルトとして、ログインユーザが表示されるが変更可能
　・ログインユーザの所属する法人の分類が、「ＹＥＳ本社」以外の場合
　　→ 担当者としてログインユーザがセットされ、変更不可

　*上記の場合、整備会社のユーザも、「 担当者としてログインユーザがセットされ、変更不可」となるが、
　　そもそも整備会社に流通関係の機能を公開していないので、直接影響はない。
