### PR TITLE
新エンジンの型式選択後、対応するシリアルNoリストが準備できるまでシリアルNo欄を非活性化

### DIFF
--- a/app/assets/javascripts/engineorders.js.coffee
+++ b/app/assets/javascripts/engineorders.js.coffee
@@ -7,12 +7,14 @@ $(document).on 'ready page:load', ->
 
 @updateSerialnoOptions = () ->
   $.ajax(
-    url: '/engines/serialno_list',
-    type: 'GET',
+    url: '/engines/serialno_list'
+    type: 'GET'
     dataType: 'json'
-    data:
-      engine_model_name: $('#engineorder_new_engine_attributes_engine_model_name').val(),
-    success: (response) -> setSerialnoOptions(response),
+    data: {engine_model_name: $('#engineorder_new_engine_attributes_engine_model_name').val()}
+    beforeSend: -> $('#engineorder_new_engine_attributes_serialno').attr('disabled', 'disabled')
+    success: (response) ->
+      setSerialnoOptions(response)
+      $('#engineorder_new_engine_attributes_serialno').removeAttr('disabled')
     error: (response) -> alert('シリアルNo.情報が取得できません'))
 
 @setSerialnoOptions = (response) ->


### PR DESCRIPTION
CoffeeScript に慣れておらず、予定より diff が多いですが、実質は
- beforeSend オプションとして、シリアルNo欄の非活性化処理を追加
- success オプションに設定していた処理に、シリアルNo欄の再活性化処理を追加

のみです。
