### PR TITLE
S-01106YES本社が仕入情報を入力できる。仕入日・仕入価格（税別）・コメント（仕入）を追加

### DIFF
--- a/app/controllers/repairs_controller.rb
+++ b/app/controllers/repairs_controller.rb
@@ -343,6 +343,6 @@ class RepairsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def repair_params
-      params.require(:repair).permit(:id, :issue_no, :issue_date, :arrive_date, :start_date, :finish_date, :before_comment, :after_comment, :time_of_running, :day_of_test, :returning_comment, :arrival_comment, :order_no, :order_date, :construction_no, :desirable_finish_date, :estimated_finish_date, :engine_id, :enginestatus_id, :shipped_date, :requestpaper, :checkpaper, :paymentstatus_id)
+      params.require(:repair).permit(:id, :issue_no, :issue_date, :arrive_date, :start_date, :finish_date, :before_comment, :after_comment, :time_of_running, :day_of_test, :returning_comment, :arrival_comment, :order_no, :order_date, :construction_no, :desirable_finish_date, :estimated_finish_date, :engine_id, :enginestatus_id, :shipped_date, :requestpaper, :checkpaper, :paymentstatus_id, :purachase_date, :purachase_comment, :purachase_price)
     end
 end

--- a/app/views/engines/index.html.erb
+++ b/app/views/engines/index.html.erb
@@ -66,7 +66,7 @@
 
 
         <% unless current_user.tender? %>
-          <td class="workregist"><%= link_to '引合', new_inquiry_path(engine), class: "workregist_work" %> </td>
+          <td class="workregist"><%= link_to '引合', purchase_path(engine), class: "workregist_work" %> </td>
         <% end %>
 
         <td class="workregist-wide">

--- a/app/views/repairs/index_purchase.html.erb
+++ b/app/views/repairs/index_purchase.html.erb
@@ -52,7 +52,7 @@
         </td>
         <td><%= repair.engine.engine_model_name %></td>
         <td><%= repair.engine.serialno %></td>
-        <td class="workregist"><%= link_to '仕入詳細', purchase_path(repair), class: "workregist_show"  %></td>
+        <td class="workregist"><%= link_to '詳細', purchase_path(repair), class: "workregist_work"  %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/repairs/purchase.html.erb
+++ b/app/views/repairs/purchase.html.erb
@@ -8,24 +8,27 @@
   <%= render 'engineInfo' %>
   <% disabled_data = getDisabled_RepairFinished %>
 
- <%= "こはどこ?"%>
-　　　　　　　　　　　　　　　　　　　　　
-
 <br>
-
   <div class="field">
     <%= f.label :finish_date %><br>
-    <%= f.date_select :finish_date, :use_month_numbers => true, :start_year => 2000 %>
-  </div>
-  <div class="field">
-    <%= f.label :after_comment %><br>
-    <%= f.text_area :after_comment %>
-  </div>
-  <div class="field">
-    <%= f.label :checkpaper %><br>
-    <%= f.file_field :checkpaper %> 
+    <%= f.date_select :finish_date, :use_month_numbers => true, :start_year => 2000, :disabled=> true  %>
   </div>
   <br>
+  <div class="field">
+    <%= f.label  :purchase_date %><br>
+    <%= f.date_select :purachase_date, :use_month_numbers => true, :start_year => 2000 %>
+  </div>
+
+  <div class="field">
+    <%= f.label :purchase_price %><br>
+    <%= f.text_field :purachase_price %>
+  </div>
+
+   <div class="field">
+    <%= f.label :purchase_comment %><br>
+    <%= f.text_area :purachase_comment %>
+  </div>
+
   <br>
   <div class="actions">
     <%= f.submit :value => t('views.buttun_repairpurchase'), :confirm => t('views.buttun_repairpurchase')+t('views.confirm_msg') %>
@@ -81,8 +84,16 @@
     <%= f.date_select :estimated_finish_date, :use_month_numbers => true, :disabled=>disabled_data[:estimated_finish_date], :start_year => 2000 %>
   </div>
   <div class="field">
-    <%= f.label :before_comment %><br>
-    <%= f.text_area :before_comment, :disabled=>disabled_data[:before_comment] %>
+    <%= label_tag '組立チェックシート' %><br>
+    <% if @repair.checkpaper.present? %>
+      <%= link_to "ダウンロード", @repair.checkpaper_url(:display), :target=>'_blank', class: "btn btn-xs btn-default" %>
+    <% else %>
+      ファイルなし<br>
+    <% end %>
+  </div>
+   <div class="field">
+    <%= f.label :after_comment %><br>
+    <%= f.text_area :after_comment, :disabled=> true %>
   </div>
   </div>
   </div>

--- a/config/locales/attributes.ja.yml
+++ b/config/locales/attributes.ja.yml
@@ -39,6 +39,9 @@ ja:
         change_comment: コメント(交換理由)
         requestpaper: 整備依頼書
         checkpaper: 組立チェックシート
+        purchase_date: 仕入日
+        purchase_comment: コメント（仕入）
+        purchase_price: 仕入価格（税抜）
       user:
         userid: ログインＩＤ
         code: 社員コード


### PR DESCRIPTION
画面名を「仕入登録」に変更
画面レイアウトを変更
・完了日を編集できない状態に
・コメント（完了）を左側に移動
・組立チェックシートの表示を左側に移動
・仕入日の追加
・仕入価格（税別）の追加
・コメント（仕入）の追加
