### PR TITLE
TK-01240 仕入れ価格　カンマを入れても入れなくても同じ値が登録される

### DIFF
--- a/app/models/repair.rb
+++ b/app/models/repair.rb
@@ -124,4 +124,9 @@ class Repair < ActiveRecord::Base
     return  ((Date.today - self.day_of_test)/365).ceil unless self.day_of_test.nil? 
   end
 
+  #purachase_priceをオーバーライトする
+  def purachase_price=(value)
+    self[:purachase_price] = value.gsub(/,/, '')
+  end
+  
 end

--- a/app/views/repairs/purchase.html.erb
+++ b/app/views/repairs/purchase.html.erb
@@ -26,9 +26,10 @@
   <br>
   <div class="field">
     <%= f.label :purchase_price %><br>
-    <%= f.text_field :purachase_price %>
-  </div>
-  <br>
+
+    <%= f.text_field :purachase_price, :value=>number_with_delimiter(@repair.purachase_price), :autocomplete=>'off', :style=>"text-align:right" %> 円
+    </div>
+  <br> 
    <div class="field">
     <%= f.label :purchase_comment %><br>
     <%= f.text_area :purachase_comment %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -227,3 +227,4 @@ ja:
     engineorder_shipping_not_undoable: 出荷を取り消せません
     engine_deleted: エンジン情報を削除しました
     engine_not_deleted: エンジン情報は削除できません
+   


### PR DESCRIPTION
カンマをいてれも入れなくても（登録後）、仕入れ価格（税別）にカンマつきで表示される。
追加で、右寄せ表示にしました。

DBに格納時、カンマを取った値にオーバーライトして格納するようにしました。
