### PR TITLE
[TK-01242] 一覧データの CSV ファイル名を変更

### DIFF
--- a/app/controllers/repairs_controller.rb
+++ b/app/controllers/repairs_controller.rb
@@ -269,9 +269,11 @@ class RepairsController < ApplicationController
   # 未請求作業一覧を表示する
   def index_unbilled
     respond_to do |format|
+      cutoff_date = ApplicationController.helpers.cutoff_date
       @repairs = Repair.joins(:engine)
                        .where(paymentstatus_id: Paymentstatus.of_unpaid,
                               engines: {enginestatus_id: Enginestatus.of_finished_repair})
+                       .where("finish_date <= ?", cutoff_date)
                        .order(:finish_date)
       format.html {
         @repairs = @repairs.paginate(page: params[:page], per_page: 10)
@@ -292,8 +294,9 @@ class RepairsController < ApplicationController
                     ApplicationController.helpers.carry_over_mark(repair)]
           end
         }
-        send_data(csv_str.encode(Encoding::SJIS),
-                  type: "text/csv; charset=shift_jis", filename: "data.csv")
+
+        send_data(csv_str.encode(Encoding::SJIS), type: "text/csv; charset=shift_jis",
+                  filename: "#{cutoff_date.year}年#{cutoff_date.month}月度求償分.csv")
       }
     end
   end

--- a/app/helpers/repairs_helper.rb
+++ b/app/helpers/repairs_helper.rb
@@ -126,8 +126,16 @@ def getDisabled_RepairFinished
   end
 end
 
+def cutoff_date
+  # TODO: 締め日を常数定義すること
+  if Date.today.day > 25
+    Date.new(Date.today.next_month.year, Date.today.next_month.month, 25)
+  else
+    Date.new(Date.today.year, Date.today.month, 25)
+  end
+end
+
 def carried_over?(repair)
-  cutoff_date = Date.new(Date.today.year, Date.today.month, 25) # TODO: 締め日を常数定義すること
   prev_cutoff_date = cutoff_date.advance(months: -1)
   repair.finish_date <= prev_cutoff_date
 end

--- a/test/fixtures/repairs.yml
+++ b/test/fixtures/repairs.yml
@@ -430,3 +430,327 @@ repair_201409_4:
   engine: engine7
   company: company2
   paymentstatus_id: <%= Paymentstatus::ID_UNPAID %>
+
+repair_201409_5:
+  issue_no: "201409-005"
+  order_no: "201409-005"
+  issue_date:  "2014-09-05"
+  order_date:  "2014-09-05"
+  arrive_date: "2014-09-05"
+  start_date:  "2014-09-05"
+  finish_date: "2014-09-05"
+  engine: engine7
+  company: company2
+  paymentstatus_id: <%= Paymentstatus::ID_UNPAID %>
+
+repair_201409_6:
+  issue_no: "201409-006"
+  order_no: "201409-006"
+  issue_date:  "2014-09-06"
+  order_date:  "2014-09-06"
+  arrive_date: "2014-09-06"
+  start_date:  "2014-09-06"
+  finish_date: "2014-09-06"
+  engine: engine7
+  company: company2
+  paymentstatus_id: <%= Paymentstatus::ID_UNPAID %>
+
+repair_201409_7:
+  issue_no: "201409-007"
+  order_no: "201409-007"
+  issue_date:  "2014-09-07"
+  order_date:  "2014-09-07"
+  arrive_date: "2014-09-07"
+  start_date:  "2014-09-07"
+  finish_date: "2014-09-07"
+  engine: engine7
+  company: company2
+  paymentstatus_id: <%= Paymentstatus::ID_UNPAID %>
+
+repair_201409_8:
+  issue_no: "201409-008"
+  order_no: "201409-008"
+  issue_date:  "2014-09-08"
+  order_date:  "2014-09-08"
+  arrive_date: "2014-09-08"
+  start_date:  "2014-09-08"
+  finish_date: "2014-09-08"
+  engine: engine7
+  company: company2
+  paymentstatus_id: <%= Paymentstatus::ID_UNPAID %>
+
+repair_201409_9:
+  issue_no: "201409-009"
+  order_no: "201409-009"
+  issue_date:  "2014-09-09"
+  order_date:  "2014-09-09"
+  arrive_date: "2014-09-09"
+  start_date:  "2014-09-09"
+  finish_date: "2014-09-09"
+  engine: engine7
+  company: company2
+  paymentstatus_id: <%= Paymentstatus::ID_UNPAID %>
+
+repair_201409_10:
+  issue_no: "201409-010"
+  order_no: "201409-010"
+  issue_date:  "2014-09-10"
+  order_date:  "2014-09-10"
+  arrive_date: "2014-09-10"
+  start_date:  "2014-09-10"
+  finish_date: "2014-09-10"
+  engine: engine7
+  company: company2
+  paymentstatus_id: <%= Paymentstatus::ID_UNPAID %>
+
+repair_201409_11:
+  issue_no: "201409-011"
+  order_no: "201409-011"
+  issue_date:  "2014-09-11"
+  order_date:  "2014-09-11"
+  arrive_date: "2014-09-11"
+  start_date:  "2014-09-11"
+  finish_date: "2014-09-11"
+  engine: engine7
+  company: company2
+  paymentstatus_id: <%= Paymentstatus::ID_UNPAID %>
+
+repair_201409_12:
+  issue_no: "201409-012"
+  order_no: "201409-012"
+  issue_date:  "2014-09-12"
+  order_date:  "2014-09-12"
+  arrive_date: "2014-09-12"
+  start_date:  "2014-09-12"
+  finish_date: "2014-09-12"
+  engine: engine7
+  company: company2
+  paymentstatus_id: <%= Paymentstatus::ID_UNPAID %>
+
+repair_201409_13:
+  issue_no: "201409-013"
+  order_no: "201409-013"
+  issue_date:  "2014-09-13"
+  order_date:  "2014-09-13"
+  arrive_date: "2014-09-13"
+  start_date:  "2014-09-13"
+  finish_date: "2014-09-13"
+  engine: engine7
+  company: company2
+  paymentstatus_id: <%= Paymentstatus::ID_UNPAID %>
+
+repair_201409_14:
+  issue_no: "201409-014"
+  order_no: "201409-014"
+  issue_date:  "2014-09-14"
+  order_date:  "2014-09-14"
+  arrive_date: "2014-09-14"
+  start_date:  "2014-09-14"
+  finish_date: "2014-09-14"
+  engine: engine7
+  company: company2
+  paymentstatus_id: <%= Paymentstatus::ID_UNPAID %>
+
+repair_201409_15:
+  issue_no: "201409-015"
+  order_no: "201409-015"
+  issue_date:  "2014-09-15"
+  order_date:  "2014-09-15"
+  arrive_date: "2014-09-15"
+  start_date:  "2014-09-15"
+  finish_date: "2014-09-15"
+  engine: engine7
+  company: company2
+  paymentstatus_id: <%= Paymentstatus::ID_UNPAID %>
+
+repair_201409_16:
+  issue_no: "201409-016"
+  order_no: "201409-016"
+  issue_date:  "2014-09-16"
+  order_date:  "2014-09-16"
+  arrive_date: "2014-09-16"
+  start_date:  "2014-09-16"
+  finish_date: "2014-09-16"
+  engine: engine7
+  company: company2
+  paymentstatus_id: <%= Paymentstatus::ID_UNPAID %>
+
+repair_201409_17:
+  issue_no: "201409-017"
+  order_no: "201409-017"
+  issue_date:  "2014-09-17"
+  order_date:  "2014-09-17"
+  arrive_date: "2014-09-17"
+  start_date:  "2014-09-17"
+  finish_date: "2014-09-17"
+  engine: engine7
+  company: company2
+  paymentstatus_id: <%= Paymentstatus::ID_UNPAID %>
+
+repair_201409_18:
+  issue_no: "201409-018"
+  order_no: "201409-018"
+  issue_date:  "2014-09-18"
+  order_date:  "2014-09-18"
+  arrive_date: "2014-09-18"
+  start_date:  "2014-09-18"
+  finish_date: "2014-09-18"
+  engine: engine7
+  company: company2
+  paymentstatus_id: <%= Paymentstatus::ID_UNPAID %>
+
+repair_201409_19:
+  issue_no: "201409-019"
+  order_no: "201409-019"
+  issue_date:  "2014-09-19"
+  order_date:  "2014-09-19"
+  arrive_date: "2014-09-19"
+  start_date:  "2014-09-19"
+  finish_date: "2014-09-19"
+  engine: engine7
+  company: company2
+  paymentstatus_id: <%= Paymentstatus::ID_UNPAID %>
+
+repair_201409_20:
+  issue_no: "201409-020"
+  order_no: "201409-020"
+  issue_date:  "2014-09-20"
+  order_date:  "2014-09-20"
+  arrive_date: "2014-09-20"
+  start_date:  "2014-09-20"
+  finish_date: "2014-09-20"
+  engine: engine7
+  company: company2
+  paymentstatus_id: <%= Paymentstatus::ID_UNPAID %>
+
+repair_201409_21:
+  issue_no: "201409-021"
+  order_no: "201409-021"
+  issue_date:  "2014-09-21"
+  order_date:  "2014-09-21"
+  arrive_date: "2014-09-21"
+  start_date:  "2014-09-21"
+  finish_date: "2014-09-21"
+  engine: engine7
+  company: company2
+  paymentstatus_id: <%= Paymentstatus::ID_UNPAID %>
+
+repair_201409_22:
+  issue_no: "201409-022"
+  order_no: "201409-022"
+  issue_date:  "2014-09-22"
+  order_date:  "2014-09-22"
+  arrive_date: "2014-09-22"
+  start_date:  "2014-09-22"
+  finish_date: "2014-09-22"
+  engine: engine7
+  company: company2
+  paymentstatus_id: <%= Paymentstatus::ID_UNPAID %>
+
+repair_201409_23:
+  issue_no: "201409-023"
+  order_no: "201409-023"
+  issue_date:  "2014-09-23"
+  order_date:  "2014-09-23"
+  arrive_date: "2014-09-23"
+  start_date:  "2014-09-23"
+  finish_date: "2014-09-23"
+  engine: engine7
+  company: company2
+  paymentstatus_id: <%= Paymentstatus::ID_UNPAID %>
+
+repair_201409_24:
+  issue_no: "201409-024"
+  order_no: "201409-024"
+  issue_date:  "2014-09-24"
+  order_date:  "2014-09-24"
+  arrive_date: "2014-09-24"
+  start_date:  "2014-09-24"
+  finish_date: "2014-09-24"
+  engine: engine7
+  company: company2
+  paymentstatus_id: <%= Paymentstatus::ID_UNPAID %>
+
+repair_201409_25:
+  issue_no: "201409-025"
+  order_no: "201409-025"
+  issue_date:  "2014-09-25"
+  order_date:  "2014-09-25"
+  arrive_date: "2014-09-25"
+  start_date:  "2014-09-25"
+  finish_date: "2014-09-25"
+  engine: engine7
+  company: company2
+  paymentstatus_id: <%= Paymentstatus::ID_UNPAID %>
+
+repair_201409_26:
+  issue_no: "201409-026"
+  order_no: "201409-026"
+  issue_date:  "2014-09-26"
+  order_date:  "2014-09-26"
+  arrive_date: "2014-09-26"
+  start_date:  "2014-09-26"
+  finish_date: "2014-09-26"
+  engine: engine7
+  company: company2
+  paymentstatus_id: <%= Paymentstatus::ID_UNPAID %>
+
+repair_201409_27:
+  issue_no: "201409-027"
+  order_no: "201409-027"
+  issue_date:  "2014-09-27"
+  order_date:  "2014-09-27"
+  arrive_date: "2014-09-27"
+  start_date:  "2014-09-27"
+  finish_date: "2014-09-27"
+  engine: engine7
+  company: company2
+  paymentstatus_id: <%= Paymentstatus::ID_UNPAID %>
+
+repair_201409_28:
+  issue_no: "201409-028"
+  order_no: "201409-028"
+  issue_date:  "2014-09-28"
+  order_date:  "2014-09-28"
+  arrive_date: "2014-09-28"
+  start_date:  "2014-09-28"
+  finish_date: "2014-09-28"
+  engine: engine7
+  company: company2
+  paymentstatus_id: <%= Paymentstatus::ID_UNPAID %>
+
+repair_201409_29:
+  issue_no: "201409-029"
+  order_no: "201409-029"
+  issue_date:  "2014-09-29"
+  order_date:  "2014-09-29"
+  arrive_date: "2014-09-29"
+  start_date:  "2014-09-29"
+  finish_date: "2014-09-29"
+  engine: engine7
+  company: company2
+  paymentstatus_id: <%= Paymentstatus::ID_UNPAID %>
+
+repair_201409_30:
+  issue_no: "201409-030"
+  order_no: "201409-030"
+  issue_date:  "2014-09-30"
+  order_date:  "2014-09-30"
+  arrive_date: "2014-09-30"
+  start_date:  "2014-09-30"
+  finish_date: "2014-09-30"
+  engine: engine7
+  company: company2
+  paymentstatus_id: <%= Paymentstatus::ID_UNPAID %>
+
+repair_201410_1:
+  issue_no: "201410-001"
+  order_no: "201410-001"
+  issue_date:  "2014-10-01"
+  order_date:  "2014-10-01"
+  arrive_date: "2014-10-01"
+  start_date:  "2014-10-01"
+  finish_date: "2014-10-01"
+  engine: engine7
+  company: company2
+  paymentstatus_id: <%= Paymentstatus::ID_UNPAID %>


### PR DESCRIPTION
- 未請求一覧からダウンロードする CSV ファイル名を data.csv から yyyy年mm月度求償分.csv に変更
- CSV ダウンロード日が締め日以降だが翌月に入っていない場合に、正しく締め日を認識できない既存の不具合を修正
