### PR TITLE
[TK-01244] 「詳細」リンクから遷移した先の画面にある「修正」リンクを削除する

### DIFF
--- a/app/views/repairs/show.html.erb
+++ b/app/views/repairs/show.html.erb
@@ -74,7 +74,9 @@
 
 <br><br>
 <% if current_user.yesOffice? || current_user.systemAdmin? %>
-  <%= link_to t('views.link_edit'), edit_repair_path(@repair) %> |
+  <% unless anchor_path =~ /#{unbilled_repairs_path}/ # ヤンマー未検収一覧から遷移した場合は編集不可 %>
+    <%= link_to t('views.link_edit'), edit_repair_path(@repair) %> |
+  <% end %>
 <% end %>
 <% if notice == t("controller_msg.repair_created") %>
   <%= link_to t('views.link_back'), anchor_path %>


### PR DESCRIPTION
- 「戻る」リンクの宛先を利用して、ヤンマー未検収一覧から遷移したことを判定しています
