### PR TITLE
流通画面の検索条件をエンジン一覧と同じにする。

### DIFF
--- a/app/controllers/engineorders_controller.rb
+++ b/app/controllers/engineorders_controller.rb
@@ -35,29 +35,48 @@ class EngineordersController < ApplicationController
       # Arel は SQL を組み立てるための DSL のようなもので、文字列として SQL 文の
       # 断片を埋め込む必要も無くなり、DBMS を取り替えやすくなります。
     arel = Engineorder.arel_table
-    arel_place = Place.arel_table
+    arel_engine = Engine.arel_table
+    #検索条件統一化のため一旦コメントアウト
+    #arel_place = Place.arel_table
+    
+    arel_engine = Engine.arel_table
+
     cond = []
 
-    # ビジネスステータス（ステータス）
-    if businessstatus_id = @searched[:businessstatus_id]
-      cond.push(arel[:businessstatus_id].eq businessstatus_id)
-    end
-
-    #拠点
+    #拠点：管轄
      if company_id = @searched[:company_id]
       cond.push(arel[:branch_id].eq company_id)
     end
 
-    #物件名
-    if title = @searched[:title]
-      cond.push(arel[:title].matches "%#{title}%")
+    # 返却エンジン型式（エンジン型式）
+    if old_engine_id = @searched[:old_engine_id]
+      cond.push(arel[:old_engine_id].eq old_engine_id)
     end
 
+   #エンジンNo
+    if serialno = @searched[:serialno]
+       engineid = Engine.where(arel_engine[:serialno].matches "%#{serialno}%").pluck(:id)
+      cond.push(arel[:old_engine_id].in engineid)
+    end
+
+   # ビジネスステータス（ステータス）
+    if businessstatus_id = @searched[:businessstatus_id]
+      cond.push(arel[:businessstatus_id].eq businessstatus_id)
+    end
+
+
+ #検索条件統一化のため一旦コメントアウト
     #物件名
-      if name = @searched[:name]
-        place = Place.where(arel_place[:name].matches "%#{name}%").pluck(:id)
-        cond.push(arel[:install_place_id].in place)
-      end
+      #if title = @searched[:title]
+        #cond.push(arel[:title].matches "%#{title}%")
+      #end
+
+    #物件名
+      #if name = @searched[:name]
+        #place = Place.where(arel_place[:name].matches "%#{name}%").pluck(:id)
+        #cond.push(arel[:install_place_id].in place)
+      #end
+
 
 
     #Yes本社の場合全件表示、それ以外の場合は拠点管轄の引合のみ対象とする。

--- a/app/views/engineorders/index.html.erb
+++ b/app/views/engineorders/index.html.erb
@@ -4,25 +4,28 @@
 <%= form_tag(engineorders_index_path, :method => :get) do %>
 <div class="well">
   <tr>
-    <td width="80">ステータス</td>
-    <td with="120"><%= collection_select(:search, :businessstatus_id, Businessstatus.all, :id, :name, :include_blank => true, :selected => @searched[:businessstatus_id]) %></td>
-    <td width="80" >拠　　　点</td>
+    <td width="80" > 拠点 ： 管轄 </td>
     <td width="120"><%= collection_select(:search, :company_id, Company.all, :id, :name, :include_blank => true, :selected => @searched[:company_id]) %></td>
-　　</tr>
-  <br>
-  <br>
   <tr>
-      <td width="80" >物 件 名</td>
-      <td width="120"><%= text_field :search, :title, :value => @searched[:title] %></td>
-      <td width="80" >設置先名</td>
-      <td width="120"><%= text_field :search, :name, :value => @searched[:name] %></td>
-  </tr>
+　 <br>
+    <br>
+  <tr>
+    <td width="80">エンジン型式</td>
+    <td with="120"><%= collection_select(:search, :old_engine_id, Enginemodel.all, :id, :name, :include_blank => true, :selected => @searched[:old_engine_id]) %></td>
+    <td width="80" >エンジンNo</td>
+    <td width="120"><%= text_field :search, :serialno, :value => @searched[:serialno] %></td>
+  <tr>
+    <br>
+    <br>
+  <tr>
+    <td width="80"> ステータス </td>
+    <td with="120"><%= collection_select(:search, :businessstatus_id, Businessstatus.all, :id, :name, :include_blank => true, :selected => @searched[:businessstatus_id]) %></td>
+ </tr>
   <br>
   <br>
-<%= submit_tag "検索" %>
+  <%= submit_tag "検索" %>
 <% end %>
 </div>
-
 <table class="table table-striped table-bordered table-condensed">
   <thead>
     <tr>


### PR DESCRIPTION
流通一覧画面の検索条件をエンジン一覧と同じ
・拠点：管轄
・エンジン型式
・エンジンNo
・ステータス
に統一しました。
