### PR TITLE
[TK-01288] CSV ダウンロード後に「戻る」リンクのあて先が不正となる不具合を修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,7 +21,9 @@ class ApplicationController < ActionController::Base
 
   private
   def anchor!
-    flash[:anchor_path] = request.original_fullpath
+    unless request.format.csv?
+      flash[:anchor_path] = request.original_fullpath
+    end
   end
 
   def keep_anchor!


### PR DESCRIPTION
他の画面も含めて、CSV ダウンロード時は「戻る」リンクのあて先を更新すべきではないので、#anchor! メソッドでリクエストの format が CSV の場合はイカリの位置を変えないように修正しました。
