### PR TITLE
TK-01290：purchaseの綴りをわざと間違える（日本語化ラベル対応）

### DIFF
--- a/app/views/repairs/index_charge.html.erb
+++ b/app/views/repairs/index_charge.html.erb
@@ -33,11 +33,11 @@
       <th>拠点</th>
       <% end %>
       <th><%= Repair.human_attribute_name(:order_no) %></th>
-      <th><%= Repair.human_attribute_name(:purchase_date) %></th>
+      <th><%= Repair.human_attribute_name(:purachase_date) %></th>
       <th><%= Engine.human_attribute_name(:engine_model_name) %></th>
       <th><%= Engine.human_attribute_name(:serialno) %></th>
       <th><%= Engineorder.human_attribute_name(:sales_amount) %></th>
-      <th><%= Repair.human_attribute_name(:purchase_price) %></th>
+      <th><%= Repair.human_attribute_name(:purachase_price) %></th>
 
       <th class="workregist">詳細情報</th>
 


### PR DESCRIPTION
purchase→ purachaseに変更
（モデルの項目名も含め、後でみんなまとめて修正する方向で…）
