### PR TITLE
ヤンマー検収済一覧画面関連の修正

### DIFF
--- a/app/controllers/repairs_controller.rb
+++ b/app/controllers/repairs_controller.rb
@@ -389,9 +389,9 @@ class RepairsController < ApplicationController
           @repairs.each do |repair|
             csv << [repair.order_no, repair.purachase_date,
                     repair.engine.engine_model_name, repair.engine.serialno,
-                    repair.purachase_price]
+                    repair.purachase_price.to_s.gsub(/(\d)(?=(\d{3})+(?!\d))/, '\1,')]
           end
-          csv << ["合計仕入価格", @total_price]
+          csv << ["合計仕入価格", @total_price.to_s.gsub(/(\d)(?=(\d{3})+(?!\d))/, '\1,')]
         }
         send_data(csv_str.encode(Encoding::SJIS),
                   type: "text/csv; charset=shift_jis", filename: "purchase_date.csv")

--- a/app/views/repairs/index_purchase.html.erb
+++ b/app/views/repairs/index_purchase.html.erb
@@ -25,11 +25,11 @@
   <thead>
     <tr>
       <th><%= Repair.human_attribute_name(:order_no) %></th>
+      <th><%= Repair.human_attribute_name(:competitor_code) %></th>
       <th><%= Repair.human_attribute_name(:purachase_date) %></th>
       <th><%= Engine.human_attribute_name(:engine_model_name) %></th>
       <th><%= Engine.human_attribute_name(:serialno) %></th>
       <th><%= Repair.human_attribute_name(:purachase_price) %></th>
-      <th class="workregist">詳細情報</th>
     </tr>
   </thead>
 
@@ -37,11 +37,11 @@
     <% @repairs.each do |repair| %>
       <tr>
         <td><%= repair.order_no %></td>
+        <td><%= repair.competitor_code %></td>
         <td><%= repair.purachase_date %></td>
         <td><%= repair.engine.engine_model_name %></td>
         <td><%= repair.engine.serialno %></td>
-        <td><%= repair.purachase_price %></td>
-        <td class="workregist"><%= link_to t('views.link_show'), repair, class: 'workregist_show' %></td>
+        <td><%= number_with_delimiter(repair.purachase_price) %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/repairs/show.html.erb
+++ b/app/views/repairs/show.html.erb
@@ -83,7 +83,7 @@
     </div>
     <div class="field">
       <%= Repair.human_attribute_name('purachase_price') %>：
-      <%= @repair.purachase_price %> 円
+      <%= number_with_delimiter(@repair.purachase_price) %> 円
     </div>
     <div class="field">
       <%= Repair.human_attribute_name('purachase_comment') %>：


### PR DESCRIPTION
TK-01252 仕入金額はカンマ区切りで表示する(画面)
TK-01253 仕入金額はカンマ区切りにする（CSV）
TK-01254 他社品コードの表示を追加する
TK-01255 詳細画面へのリンクを削除する
を反映
