### PR TITLE
S-01068 整備会社の担当者が、整備会社作業一覧画面で、エンジン型式、シリアルNo、ステータスで検索できる

### DIFF
--- a/app/views/engineorders/index.html.erb
+++ b/app/views/engineorders/index.html.erb
@@ -11,7 +11,7 @@
     <br>
   <tr>
     <td width="80">エンジン型式</td>
-    <td with="120"><%= collection_select(:search, :modelcode, Enginemodel.all, :modelcode, :modelcode, :include_blank => true, :selected => @searched[:modelcode]) %></td>
+    <td width="120"><%= collection_select(:search, :modelcode, Enginemodel.all, :modelcode, :modelcode, :include_blank => true, :selected => @searched[:modelcode]) %></td>
     <td width="80" >エンジンNo</td>
     <td width="120"><%= text_field :search, :serialno, :value => @searched[:serialno] %></td>
   <tr>

--- a/app/views/repairs/index.html.erb
+++ b/app/views/repairs/index.html.erb
@@ -11,7 +11,7 @@
 <br>
 <tr>
       <td width="80" >エンジン型式</td>
-      <td width="120"><%= text_field :search, :engine_model_name, :value => @searched[:engine_model_name] %></td>
+      <td width="120"><%= collection_select(:search, :engine_model_name, Enginemodel.all, :modelcode, :modelcode, :include_blank => true, :selected => @searched[:engine_model_name]) %></td>
       <td width="80" >エンジンNo.</td>
       <td width="120"><%= text_field :search, :serialno, :value => @searched[:serialno] %><br /></td>
 </tr>


### PR DESCRIPTION
S-01068 整備会社の担当者が、整備会社作業一覧画面で、エンジン型式、シリアルNo、ステータスで検索できる
　→整備会社作業一覧（Repair/index.html.erb）にて、エンジン型式のテキストフィールドを、エンジン型式テーブルからのドロップリストに変更
