### PR TITLE
[TK-01256] 検索条件に整備会社を追加する

### DIFF
--- a/app/views/repairs/index_purchase.html.erb
+++ b/app/views/repairs/index_purchase.html.erb
@@ -12,6 +12,13 @@
                                                    default: {year: @searched[:"purchase_month(1i)"], month: @searched[:"purchase_month(2i)"]}  %>
         </td>
       </tr>
+      <tr>
+        <td width="80">整備会社</td>
+        <td width="120">
+          <%= collection_select(:search, :company_id, Company.all.tender, :id, :name,
+                                include_blank: true, selected: @searched[:company_id]) %>
+        </td>
+      </tr>
     </table>
     <br>
     <%= submit_tag "検索" %>


### PR DESCRIPTION
ヤンマー未検収一覧の CSV 出力機能と仕様を統一するため、
- 検索条件に整備会社を指定した場合  => yyyy年mm月仕入分（整備会社名）.csv
- 検索条件の整備会社を指定しなかった場合 => yyyy年mm月仕入分（ALL）.csv
  としています。
