### PR TITLE
[TK-01303] 運転時間の入力を半角数字のみとする

### DIFF
--- a/app/models/engineorder.rb
+++ b/app/models/engineorder.rb
@@ -37,6 +37,10 @@ class Engineorder < ActiveRecord::Base
   #旧エンジンは必ず流通登録に必要なので、必須項目とする。
   validates :old_engine, presence: true
 
+  # View でも数値以外入力できないように制限しているが、ブラウザ以外のクライアン
+  # トなども考慮して、Model でもバリデーションを設定しておく。
+  validates_numericality_of :time_of_running
+
   accepts_nested_attributes_for :old_engine
   accepts_nested_attributes_for :new_engine
 

--- a/app/views/engineorders/_form.html.erb
+++ b/app/views/engineorders/_form.html.erb
@@ -151,7 +151,8 @@
 -->
   <div class="field">
     <%= f.label :time_of_running %><br>
-    <%= f.number_field :time_of_running %>
+    <%= f.text_field :time_of_running, style: "ime-mode:disabled;",
+                     onkeyup: raw("if (/\\D/g.test(this.value)) this.value = this.value.replace(/\\D/g, '')") %>
   </div>
   <div class="field">
     <%= f.label :day_of_test %><br>

--- a/app/views/engineorders/inquiry.html.erb
+++ b/app/views/engineorders/inquiry.html.erb
@@ -100,7 +100,8 @@
 
   <div class="field">
     <%= f.label :time_of_running %><br>
-    <%= f.number_field :time_of_running %>
+    <%= f.text_field :time_of_running, style: "ime-mode:disabled;",
+                     onkeyup: raw("if (/\\D/g.test(this.value)) this.value = this.value.replace(/\\D/g, '')") %>
   </div>
 
   <div class="field">


### PR DESCRIPTION
運転時間の入力制限を、
- 入力欄にフォーカスがあたったタイミングで IME をオフにする
- 半角英字など数字以外のものを入力すると、その文字を自動でバックスペースで消すような動きで嫌がる
- 念のためモデルのバリデーションも追加

で、対応してみました。
