### PR TITLE
Sprint10スプリントレビュー後の追加ストーリの適用

### DIFF
--- a/app/views/companies/_form.html.erb
+++ b/app/views/companies/_form.html.erb
@@ -23,10 +23,7 @@
     <%= f.label :phone_no %><br>
     <%= f.text_field :phone_no %>
   </div>
-  <div class="field">
-    <%= f.label :destination_name %><br>
-    <%= f.text_field :destination_name %>
-  </div>
+  
   <div class="actions">
     <%= f.submit %>
   </div>

--- a/app/views/companies/index.html.erb
+++ b/app/views/companies/index.html.erb
@@ -8,7 +8,6 @@
       <th>郵便番号</th>
       <th>住所</th>
       <th>電話番号</th>
-      <th>宛先</th>
       <th>更新日</th>
       <th></th>
       <th></th>
@@ -23,7 +22,6 @@
         <td><%= company.postcode %></td>
         <td><%= company.address %></td>
         <td><%= company.phone_no %></td>
-        <td><%= company.destination_name %></td>
         <td><%= company.updated_at %></td>        
         <td><%= link_to '詳細', company, class: "workregist_show"  %></td>
         <td><%= link_to '修正', edit_company_path(company) , class: "workregist_edit" %></td>

--- a/app/views/companies/show.html.erb
+++ b/app/views/companies/show.html.erb
@@ -23,10 +23,5 @@
   <%= @company.phone_no %>
 </p>
 
-<p>
-  <strong>宛先:</strong>
-  <%= @company.destination_name %>
-</p>
-
 <%= link_to '編集', edit_company_path(@company) %> |
 <%= link_to '戻る', companies_path %>


### PR DESCRIPTION
TK-01320　（全般）金額関連の表示は全て3桁カンマ区切りとする。

TK-01325　　法人マスターの宛先は利用しないため、削除する。

を適用
