### PR TITLE
TK-01303 の対応で、運転時間の入力が必須となってしまったので省略可能に戻した

### DIFF
--- a/app/models/engineorder.rb
+++ b/app/models/engineorder.rb
@@ -39,7 +39,7 @@ class Engineorder < ActiveRecord::Base
 
   # View でも数値以外入力できないように制限しているが、ブラウザ以外のクライアン
   # トなども考慮して、Model でもバリデーションを設定しておく。
-  validates_numericality_of :time_of_running
+  validates_numericality_of :time_of_running, allow_nil: true
 
   accepts_nested_attributes_for :old_engine
   accepts_nested_attributes_for :new_engine


### PR DESCRIPTION
勢い余った件です。。。
