### PR TITLE
引合登録で必須項目バリデーションでエラーとなったときに描画する画面が不正となる不具合を修正

### DIFF
--- a/app/controllers/engineorders_controller.rb
+++ b/app/controllers/engineorders_controller.rb
@@ -170,7 +170,7 @@ class EngineordersController < ApplicationController
         format.html { redirect_to @engineorder, notice: t('controller_msg.engineorder_created') }
         format.json { render action: 'show', status: :created, location: @engineorder }
       else
-        format.html { render action: 'new' }
+        format.html { render_on_status }
         format.json { render json: @engineorder.errors, status: :unprocessable_entity }
       end
     end

--- a/test/fixtures/repairs.yml
+++ b/test/fixtures/repairs.yml
@@ -203,7 +203,7 @@ repair_201408_15:
   finish_date: "2014-08-15"
   engine: engine7
   company: company2
-   construction_no: "CN000016"
+  construction_no: "CN000016"
   paymentstatus_id: <%= Paymentstatus::ID_UNPAID %>
 
 repair_201408_16:


### PR DESCRIPTION
Repair の fixture 中に余分な空白があったので、そこもついでに修正しています
