### PR TITLE
[TK-01413,TK-01414] 引当登録画面の残件

### DIFF
--- a/app/controllers/engineorders_controller.rb
+++ b/app/controllers/engineorders_controller.rb
@@ -284,6 +284,8 @@ class EngineordersController < ApplicationController
     if @engineorder.new_engine.nil?
       @engineorder.new_engine = Engine.new
     end
+    # 新規エンジンの型式は、返却エンジンの型式と同一
+    @engineorder.new_engine.engine_model_name = @engineorder.old_engine.engine_model_name
   end
 
   # 出荷の処理

--- a/app/models/engineorder.rb
+++ b/app/models/engineorder.rb
@@ -327,6 +327,7 @@ class Engineorder < ActiveRecord::Base
       new_engine.save!
       # 引当時に新規入力した項目をクリア
       self.new_engine = nil
+      self.returning_place = nil
       self.allocated_date = nil
       self.save!
       true

--- a/app/views/engineorders/allocated.html.erb
+++ b/app/views/engineorders/allocated.html.erb
@@ -47,23 +47,14 @@
         <tr>
           <td><%= engine_form.label :engine_model_name, Engineorder.human_attribute_name("new_engine.engine_model_name"), class: "need-label" %></td>
           <td>
-            <% if @engineorder.new_engine && !@engineorder.new_engine.engine_model_name.blank? %>
-              <% col = [@engineorder.new_engine] + Engine.completed.to_a %>
-            <% else %>
-              <% col = Engine.completed.to_a %>
-            <% end %>
-            <%= engine_form.collection_select :engine_model_name, col.compact.uniq(&:engine_model_name), :engine_model_name, :engine_model_name, include_blank: true %>
+            <%= engine_form.text_field :engine_model_name, readonly: true %>
           </td>
         </tr>
         <tr>
           <td><%= engine_form.label :serialno, Engineorder.human_attribute_name("new_engine.serialno"), class: "need-label" %></td>
           <td>
-            <% if @engineorder.new_engine && !@engineorder.new_engine.serialno.blank? %>
-              <% col = [@engineorder.new_engine] + Engine.completed.where(engine_model_name: @engineorder.new_engine.engine_model_name).to_a %>
-            <% else %>
-              <% col = [] %>
-            <% end %>
-            <%= engine_form.collection_select :serialno, col.compact.uniq(&:serialno), :serialno, :serialno, {include_blank: true}, style: "width:100%" %>
+            <% col = [@engineorder.new_engine] + Engine.completed.where(engine_model_name: @engineorder.new_engine.engine_model_name).to_a %>
+            <%= engine_form.collection_select :serialno, col.compact.uniq(&:serialno), :serialno, :serialno, style: "width:100%" %>
           </td>
         </tr>
       </table>


### PR DESCRIPTION
- [TK-01413] 新規エンジンの型式には返却エンジンの型式を表示し、変更不可とする
- [TK-01414] 新規エンジン No. は、該当型式の完成品のもののみ候補とする
- あわせて、引当の取消で、引当登録時に必須入力する「返却先」をクリアしていない不具合を修正
