### PR TITLE
S-01159 【開発チーム】Sprint12実施中に発覚した問題点等 の対応

### DIFF
--- a/app/helpers/engineorders_helper.rb
+++ b/app/helpers/engineorders_helper.rb
@@ -167,17 +167,29 @@ end
               :style=>"color:red;",
               confirm: t("controller_msg.engineorder_ordered_undoing?")
     when Businessstatus::ID_SHIPPING_PREPARATION  # 出荷準備中
-      link_to t("views.link_allocated") + "の取り消し", undo_allocation_path(engineorder),
-              :style=>"color:red;",
-              confirm: t("controller_msg.engineorder_allocation_undoing?")
+      if current_user.yesOffice? || current_user.systemAdmin? 
+        link_to t("views.link_allocated") + "の取り消し", undo_allocation_path(engineorder),
+                :style=>"color:red;",
+                confirm: t("controller_msg.engineorder_allocation_undoing?")
+      else
+        "出荷準備中 → 受注 に戻したい場合は、システム管理者にご連絡ください。"
+      end
     when Businessstatus::ID_SHIPPED  # 出荷済
-      link_to t("views.link_shipped") + "の取り消し", undo_shipping_path(engineorder),
+      if current_user.yesOffice? || current_user.systemAdmin? 
+        link_to t("views.link_shipped") + "の取り消し", undo_shipping_path(engineorder),
               :style=>"color:red;",
               confirm: t("controller_msg.engineorder_shipping_undoing?")
+      else
+        "出荷済 → 出荷準備中 に戻したい場合は、システム管理者にご連絡ください。"
+      end
     when Businessstatus::ID_RETURNED  # 返却済
-      link_to t("views.link_returning") + "の取り消し", undo_returning_path(engineorder),
+      if current_user.yesOffice? || current_user.systemAdmin? 
+        link_to t("views.link_returning") + "の取り消し", undo_returning_path(engineorder),
               :style=>"color:red;",
               confirm: t("controller_msg.engineorder_returning_undoing?")
+      else
+        "返却済 → 返却予定 に戻したい場合は、システム管理者にご連絡ください。"
+      end
     when Businessstatus::ID_CANCELED  # キャンセル
       # TODO: 未実装
       # エンジンオーダをキャンセル状態にするユースケースは無い？

--- a/app/views/engineorders/_statusrollback.html.erb
+++ b/app/views/engineorders/_statusrollback.html.erb
@@ -1,3 +1,5 @@
 <br>
 <br>
+<% if current_user.yesOffice? || current_user.systemAdmin? || @engineorder.branch_id == current_user.company_id %>
 <div class="statusrollback">[<%= engineorders_undo_link(@engineorder) %>]</div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+　　<meta name="robots" content="noindex">
   <title>R2</title>
   <%= stylesheet_link_tag    "application", media: "all", "data-turbolinks-track" => true %>
   <%= javascript_include_tag "application", "data-turbolinks-track" => true %>


### PR DESCRIPTION
TK-01420：YES拠点が「引当の取消」「出荷の取消」ができないようにする
TK-01421：流通情報一覧の詳細画面におけるYES拠点の取消は、自拠点のもののみ可能となること

また、あわせて「 S-01156：【超重要】本番リリースに向けての必要な作業」のうち、
「TK-01404：（備忘録）クロールされない設定にしておく。」に対応
