### PR TITLE
[TK-01438] 送付先マスタの担当者以外を必須入力にする

### DIFF
--- a/app/assets/javascripts/location.js
+++ b/app/assets/javascripts/location.js
@@ -35,17 +35,19 @@ function sendingPlaceChanged(category) {
     url: "/sendingplaces/" + plclist.value + ".json",
     type: "GET", 
     success: function(data) { 
+      document.getElementById(category + "_name").value = data.name;
       document.getElementById(category + "_postcode").value = data.postcode;
       document.getElementById(category + "_address").value = data.address;
       document.getElementById(category + "_phone_no").value = data.phone_no;
-      document.getElementById(category + "_destination_name").value = data.destination_name	;
-      
+      if (document.getElementById(category + "_destination_name").value == "")
+	  document.getElementById(category + "_destination_name").value = data.destination_name;
       },
     error: function() {
+      document.getElementById(category + "_name").value = "";
       document.getElementById(category + "_postcode").value = "";
       document.getElementById(category + "_address").value = "";
       document.getElementById(category + "_phone_no").value = "";
-      document.getElementById(category + "_destination_name").value = "";
+      //document.getElementById(category + "_destination_name").value = "";
       }
     
     })

--- a/app/models/engineorder.rb
+++ b/app/models/engineorder.rb
@@ -102,11 +102,6 @@ class Engineorder < ActiveRecord::Base
         sending_place.errors.add_on_blank(:phone_no)
         errors.add("sending_place.phone_no", "を入力してください")
       end
-      # 送付先 - 宛名
-      if sending_place.destination_name.blank?
-        sending_place.errors.add_on_blank(:destination_name)
-        errors.add("sending_place.destination_name", "を入力してください")
-      end
     end
     # 売上金額 (見込み)
     errors.add_on_blank(:sales_amount) if sales_amount.blank?

--- a/app/views/engineorders/ordered.html.erb
+++ b/app/views/engineorders/ordered.html.erb
@@ -35,12 +35,11 @@
     document.getElementById('sending_name').style.display = '';
     document.getElementById('select_sending').style.display = 'none';
       
-    document.getElementById('sending_name').disabled     = false;
-    document.getElementById('sending_postcode').disabled = false;
-    document.getElementById('sending_address').disabled  = false;
-    document.getElementById('sending_phone_no').disabled = false;
-    document.getElementById('sending_destination_name').disabled = false;
-    document.getElementById('sending_company').disabled = false;
+    document.getElementById('sending_name').readOnly     = false;
+    document.getElementById('sending_postcode').readOnly = false;
+    document.getElementById('sending_address').readOnly  = false;
+    document.getElementById('sending_phone_no').readOnly = false;
+    document.getElementById('sending_company').readOnly = false;
       
     clear_hand_fields();
     
@@ -51,12 +50,11 @@
     document.getElementById('sending_name').style.display = 'none'; 
     document.getElementById('select_sending').style.display = '';
 
-    document.getElementById('sending_name').disabled     = true;
-    document.getElementById('sending_postcode').disabled = true;
-    document.getElementById('sending_address').disabled  = true;
-    document.getElementById('sending_phone_no').disabled = true;
-    document.getElementById('sending_destination_name').disabled = true;
-    document.getElementById('sending_company').disabled  = true;
+    document.getElementById('sending_name').readOnly     = true;
+    document.getElementById('sending_postcode').readOnly = true;
+    document.getElementById('sending_address').readOnly  = true;
+    document.getElementById('sending_phone_no').readOnly = true;
+    document.getElementById('sending_company').readOnly  = true;
     
     sendingPlaceChanged('sending')
     
@@ -68,7 +66,6 @@
     document.getElementById('sending_postcode').value = "";
     document.getElementById('sending_address').value = "";
     document.getElementById('sending_phone_no').value = "";
-    document.getElementById('sending_destination_name').value = "";
     }
 </script>
 
@@ -177,7 +174,7 @@
           </td>
         </tr>
         <tr>
-          <td><%= p.label :destination_name, Engineorder.human_attribute_name("sending_place.destination_name"), class: "need-label" %></td>
+          <td><%= p.label :destination_name, Engineorder.human_attribute_name("sending_place.destination_name") %></td>
           <td><%= p.text_field :destination_name , :size => 20 , :disabled=> disabled_data[:sending_place], :id => :sending_destination_name  %></td>
         </tr>
         <tr>

--- a/test/fixtures/sendingplaces.yml
+++ b/test/fixtures/sendingplaces.yml
@@ -15,3 +15,11 @@ two:
   address: MyString
   phone_no: MyString
   destination_name: MyString
+
+sendingplace2:
+  branch: company8
+  name: 西宮戎リペア
+  postcode: 123-4567
+  address: 兵庫県西宮市戎西町
+  phone_no: 06-6123-4567
+  destination_name: 恵比寿様


### PR DESCRIPTION
### 目的
- 受注登録時に「送付先」をマスタから選択する場合でも、「担当者」のみ手入力できるようにする
- 受注登録時に「送付先 - 担当者」は必須項目から除外する
### 変更内容
1. 必須項目から「送付先 - 担当者」を除外する
   
   `Engineorder` モデルのバリデーションとして、受注登録時は `#validate_ordered_fields` メソッドで必須項目をチェックしています。
   このメソッドから、`sending_place.destination_name` のチェックを削除しました。
2. 「マスタから選択」時に「担当者」を手入力可能にする
   
   `app/views/engineorders/ordered.html.erb` の先頭にある Javascript コードを変更しました。
   「マスタから選択」をチェックした時に、`sending_place_changed` 関数で各入力フィールドを非活性化しています。
   　この非活性化するフィールドから `sending_destination_name` を除外しました。
3. 「担当者」フィールドの必須項目マーク（＊印）を消す
   
   `app/views/engineorders/ordered.html.erb` の `destination_name` ラベルに指定していた、`class="need-label"` を削除しました。
4. 既存不具合の修正
   
   「マスタから選択」時に、各入力フィールドを `.disable = true` としているため、HTTP リクエストにフィールドに表示している値が載らない不具合がありました。
   `.disable = true` を `.readOnly = true` に変更することで、フィールドを入力不可にするが、HTTP リクエストにはフィールドに表示している値が載るようにしました。
